### PR TITLE
Add a --no-empty flag to disallow empty env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ source ./myvalues
 ./render template.txt > rendered.txt
 ```
 
+Error out on empty env variables:
+
+```
+$ person= ./render --no-empty template.txt > rendered.txt
+```
+
 ## Testing
 
 Just run:

--- a/render
+++ b/render
@@ -24,6 +24,7 @@
 set -e
 
 no_empty=false
+
 case $1 in
     -e|--no-empty)
     no_empty=true
@@ -42,7 +43,7 @@ for varname in $varnames; do
         if [ -z ${!varname+x} ]; then
                 echo "ERROR: $varname is not defined" >&2
                 error=true
-        elif [ $no_empty='true' ] && [ -z ${!varname} ]; then
+        elif [ $no_empty = true ] && [ -z ${!varname} ]; then
                 echo "ERROR: $varname is empty" >&2
                 error=true
         else

--- a/render
+++ b/render
@@ -23,6 +23,14 @@
 # SOFTWARE.
 set -e
 
+no_empty=false
+case $1 in
+    -e|--no-empty)
+    no_empty=true
+    shift
+    ;;
+esac
+
 # Get all variable names used in the template
 varnames=$(grep -oE '\{\{([A-Za-z0-9_]+)\}\}' $1 | sed -rn 's/.*\{\{([A-Za-z0-9_]+)\}\}.*/\1/p' | sort | uniq)
 
@@ -33,6 +41,9 @@ for varname in $varnames; do
         # Check if the variable named $varname is defined
         if [ -z ${!varname+x} ]; then
                 echo "ERROR: $varname is not defined" >&2
+                error=true
+        elif [ $no_empty='true' ] && [ -z ${!varname} ]; then
+                echo "ERROR: $varname is empty" >&2
                 error=true
         else
                 # Get the value of the variable named $varname and escape

--- a/test-render
+++ b/test-render
@@ -78,7 +78,7 @@ it "does throw an error if test_variable is defined but empty if --no-empty flag
 ERROR: test_variable is empty
 EOF
 
-it "doesn' throw an error if test_variable is defined but empty and --no-empty flag is provided on last position" "test_variable=" "" "--no-empty" <<EOF
+it "doesn't throw an error if test_variable is defined but empty and --no-empty flag is provided on last position" "test_variable=" "" "--no-empty" <<EOF
 somerandomtextmorerandomtext
 \$symbol_that_doesnt_get_rendered
 EOF

--- a/test-render
+++ b/test-render
@@ -28,13 +28,13 @@ render=$parent_dir/render
 template=$parent_dir/test-template
 
 it() {
-    cmd="$2 $(basename $render) $(basename $template)"
+    cmd="$2 $(basename $render) $3 $(basename $template) $4"
     expected=
 
     while IFS= read -r line; do expected+="$line"$'\n'; done;
 
     expected=${expected%$'\n'}
-    if received=$(eval "$2 $render $template" 2>&1); then
+    if received=$(eval "$2 $render $3 $template $4" 2>&1); then
         foo=bar # noop
     fi
 
@@ -73,6 +73,16 @@ it "doesn't throw an error if test_variable is defined but empty" "test_variable
 somerandomtextmorerandomtext
 \$symbol_that_doesnt_get_rendered
 EOF
+
+it "does throw an error if test_variable is defined but empty if --no-empty flag is provided" "test_variable=" "--no-empty" <<EOF
+ERROR: test_variable is empty
+EOF
+
+it "doesn' throw an error if test_variable is defined but empty and --no-empty flag is provided on last position" "test_variable=" "" "--no-empty" <<EOF
+somerandomtextmorerandomtext
+\$symbol_that_doesnt_get_rendered
+EOF
+
 
 
 test_value='http://'$(uuidgen)'/some/path'


### PR DESCRIPTION
Just to have some stricter error checking when we know we do not want any empty env variables.