### PR TITLE
Only run sed if provided file has template values

### DIFF
--- a/render
+++ b/render
@@ -59,4 +59,7 @@ if [[ $error = true ]]; then
 elif [[ -n $expressions ]]; then
         cat $1 | eval sed -r "$expressions"
         exit 0
+else
+        cat $1
+        exit 0
 fi

--- a/render
+++ b/render
@@ -56,7 +56,7 @@ done
 
 if [[ $error = true ]]; then
         exit 1
-else
+elif [[ -n $expressions ]]; then
         cat $1 | eval sed -r "$expressions"
         exit 0
 fi


### PR DESCRIPTION
Otherwise this ends up in a very verbose log which shows the sed usage.